### PR TITLE
Removed mappings from the ScrollColor.vim plugin file.

### DIFF
--- a/plugin/ScrollColor.vim
+++ b/plugin/ScrollColor.vim
@@ -447,9 +447,6 @@ endfun
 
 command! CN :call s:NextColorscheme()
 command! CP :call s:PrevColorscheme()
-map \n :CN<cr>
-map \p :CP<cr>
-map \c :echo g:colors_name<cr>
 
 " 2006-07-18 fixed bug with Align() -> s:Align() (affected L command)
 " 2006-07-18 added colorlist cache (s:list)


### PR DESCRIPTION
The mappings in this plugin have the potential to conflict with other mappings. In regular vim, you can probably resolve this by just adding `unmap`s to your `.vimrc`. But for neovim users, since it loads plugins asynchronously, this doesn't work (the the plugin hasn't been loaded when `init.vim` is loaded, and so there is nothing for `init.vim` to unmap).

It's better to eliminate all mappings from plugins and let users create maps themselves. This PR does this.